### PR TITLE
fix: MPV process lifecycle, whitelist logging, download flush

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -214,6 +214,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                         if mpv_restart_needed {
                             println!("🔄 MPV needs restart due to changes. Restarting...");
                             mpv.kill().await?;
+                            mpv.wait().await.ok();
                             
                             // Determine the correct rotation based on current rotation setting
                             let rotation_degrees = if let Some(rotation) = data.current_rotation {
@@ -271,7 +272,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     // Force MPV restart to pick up new playlist immediately
                     println!("🔄 Restarting MPV to load new playlist...");
                     mpv.kill().await?;
-                    
+                    mpv.wait().await.ok();
+
                     // Use current rotation when restarting MPV
                     let rotation_degrees = if let Some(rotation) = data.current_rotation {
                         get_rotation_for_device(rotation)
@@ -311,11 +313,13 @@ async fn main() -> Result<(), Box<dyn Error>> {
             _ = terminate.recv() => {
                 println!("Received SIGTERM, terminating...");
                 mpv.kill().await?;
+                mpv.wait().await.ok();
                 break;
             }
             _ = interrupt.recv() => {
                 println!("Received SIGINT, terminating...");
                 mpv.kill().await?;
+                mpv.wait().await.ok();
                 break;
             }
             _ = hup.recv() => {
@@ -479,7 +483,6 @@ async fn receive_videos(
     }
 }
 
-// Removed: receive_videos_for_playlist - using legacy endpoint instead
 
 async fn update_videos(
     client: &Client,
@@ -518,7 +521,6 @@ async fn update_videos(
     Ok(())
 }
 
-// Removed: update_videos_for_playlist - using legacy endpoint instead
 
 // ============================================================================
 // NEW TIMELINE SCHEDULE FUNCTIONS

--- a/src/util.rs
+++ b/src/util.rs
@@ -88,6 +88,7 @@ impl Video {
         while let Some(content) = stream.next().await {
             tokio::io::copy(&mut content?.as_ref(), &mut file).await?;
         }
+        file.flush().await?;
 
         println!("Downloaded to: {}", file_path);
 
@@ -96,15 +97,12 @@ impl Video {
 
     pub fn in_whitelist(&self) -> bool {
         let whitelist = ["s3.amazonaws.com", "omnicommando.com"];
-
-        for url in whitelist {
-            if self.asset_url.contains(url) {
+        for domain in &whitelist {
+            if self.asset_url.contains(domain) {
                 return true;
-            } else {
-                println!("URL not in whitelist: {}", self.asset_url);
             }
         }
-
+        println!("URL not in whitelist: {}", self.asset_url);
         false
     }
 }


### PR DESCRIPTION
## Summary

- **MPV lifecycle**: Add `mpv.wait()` after every `mpv.kill()` call to prevent zombie/orphan processes on restart, content update, and signal shutdown
- **Logging**: Fix whitelist check to log once per rejected URL instead of per-domain
- **Downloads**: Add explicit `flush()` after streaming video downloads
- **Cleanup**: Remove stale "Removed:" comments

## Test plan

- [ ] Verify MPV restarts cleanly on content/rotation changes (no orphan `mpv` processes)
- [ ] Verify `systemctl stop signaged` terminates MPV cleanly
- [ ] Verify video downloads complete successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)