### PR TITLE
fix: atomic playlist.txt rebuild in update_videos

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,6 @@ use config::Config;
 use data::Data;
 use reqwest::{Client, StatusCode};
 use std::{boxed::Box, error::Error, path::Path};
-use tokio::io::AsyncWriteExt;
 use tokio::process::{Child, Command};
 use tokio::signal::unix::{signal, SignalKind};
 use tokio::time::{self, Duration};
@@ -603,24 +602,22 @@ async fn update_videos(
     data.write().await?;
     let home = std::env::var("HOME")?;
 
-    if Path::new(&format!("{home}/.local/share/signage/playlist.txt")).try_exists()? {
-        tokio::fs::remove_file(format!("{home}/.local/share/signage/playlist.txt")).await?;
-    }
-
-    let mut file = tokio::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(format!("{home}/.local/share/signage/playlist.txt"))
-        .await?;
-
+    let mut contents = String::new();
     for video in data.videos.clone() {
         if !video.in_whitelist() {
             continue;
         }
         let file_path = video.download(client).await?;
-        file.write_all(format!("{}\n", file_path).as_bytes())
-            .await?;
+        contents.push_str(&file_path);
+        contents.push('\n');
     }
+
+    // Atomic write so a crash mid-rebuild can't leave a partial playlist.txt.
+    let playlist_path = format!("{home}/.local/share/signage/playlist.txt");
+    let temp_path = format!("{playlist_path}.tmp");
+    tokio::fs::write(&temp_path, contents).await?;
+    tokio::fs::rename(&temp_path, &playlist_path).await?;
+
     cleanup_directory(&format!("{}/.local/share/signage", home)).await?;
     Ok(())
 }


### PR DESCRIPTION
## Summary
Closes a race / crash-safety gap in `update_videos`: previously `playlist.txt` was deleted and reopened in **append** mode, then written line-by-line. A crash, kill, or concurrent rebuild mid-write could leave a partial or duplicated playlist.txt on disk — which MPV (started with `--loop-playlist=inf`) would then loop forever.

Now the playlist content is built in memory, written to `playlist.txt.tmp`, and renamed — atomic at the filesystem level. Same pattern `util::write_json` already uses for `data.json`.

## What Changed
### Removed / Modified
- `update_videos` no longer pre-deletes playlist.txt or holds it open in append mode for the duration of asset downloads.
- New flow: download each whitelisted video → accumulate paths in a `String` → `tokio::fs::write(temp_path, ...)` → `tokio::fs::rename(temp_path, final_path)`.
- Dropped the now-unused `tokio::io::AsyncWriteExt` import.

## Why
Diagnosed against a production Pi that was looping stale mp4s from a leftover `playlist.txt`. The atomic write isn't the *cause* of that specific incident (a missing flag fan-out in the .NET backend was — see [oc1-api#400](https://github.com/omnicommander-oc1/oc1-api/pull/400)), but it removes the partial-file failure mode so a future crash mid-rebuild can't leave the device looping garbage.

## Files Changed
- `src/main.rs` — replaced the delete + append loop in `update_videos` (lines ~602-624) with build-in-memory + temp-rename; removed stale `AsyncWriteExt` import.

## Test Plan
- [ ] `cargo check` passes (verified locally — clean)
- [ ] Deploy to a staging Pi; confirm `update_videos` still rebuilds `playlist.txt` correctly when a content update fires
- [ ] Inspect `~/.local/share/signage/` during a rebuild: should briefly see a `playlist.txt.tmp` that disappears, never a half-written `playlist.txt`
- [ ] Confirm `cleanup_directory` still removes orphaned mp4s after the rename

🤖 Generated with [Claude Code](https://claude.com/claude-code)